### PR TITLE
Add  video link for LA R Users  talk

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,6 +63,8 @@ dask-worker-space/
 prefect-fork/*
 .pytest_cache/
 r-from-the-command-line/critiquer
+r-from-the-command-line/stderr.txt
+r-from-the-command-line/stdout.txt
 
 # editor files
 **/.idea/

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Click the "title" links below for links to slides, code, and other background in
 |["LightGBM's Road to CRAN"][7]                                                           | [satRdays Chicago (Apr 2020)][8]        |
 |["People Shape Software"][9]                                                             | [satRdays Chicago (Apr 2019)][10]       |
 |["Proliferation of New Database Technologies <br>and Implications for Data Science"][11] | [Domino Data Science Pop-Up (Oct 2017)][12] |
+|["R From the Command Line"][23]                                                          | [LA R Users (Mar 2021)][24]             |
 |["Recent Developments in LightGBM"][19]                                                  | [LA Data Science Meetup (Jan 2021)][20] |
 |["Road to a Data Science Career"][3]                                                     | [iRisk Lab Hack Night (Aug 2020)][4]    |
 |["Scaling LightGBM with Python and Dask"][5]                                             | [PyData Montreal (Jan 2021)][21]<br>[Chicago ML (Jan 2021)][22] |
@@ -50,6 +51,8 @@ Click the "title" links below for links to slides, code, and other background in
 [20]: https://www.youtube.com/watch?list=PLVwJeG_Q73i7UpMciUK7ckTD8zQc7oT0W&v=5nKSMXBFhes&feature=emb_title
 [21]: https://www.youtube.com/watch?v=vajaT1FNP6I
 [22]: https://www.youtube.com/watch?v=hK4fiXz8zXM
+[23]: ./r-from-the-command-line
+[24]: https://www.youtube.com/watch?v=5kmUE-qHziA
 
 ## Writing
 

--- a/r-from-the-command-line/DEMO.md
+++ b/r-from-the-command-line/DEMO.md
@@ -85,11 +85,15 @@ Rscript sample-r-code/print-random-numbers.R
 
 ### `-e`
 
+`-e` means "I'm passing you R code in a string, not a path to a file".
+
 ```shell
 Rscript -e "library(data.table); data.table(m = rnorm(10))"
 ```
 
 ### `--help`
+
+`--help` can be used to retrieve documentation about the available arguments.
 
 ```shell
 Rscript --help
@@ -97,17 +101,23 @@ Rscript --help
 
 ### `--version`
 
+`--version` prints the version of `Rscript`, which is almost always the same as the version of R.
+
 ```shell
 Rscript --version
 ```
 
 ### `--verbose`
 
+To get more information about what `Rscript` is doing when it runs your code, you can use `--verbose`.
+
 ```shell
 Rscript --verbose -e "library(data.table); data.table(m = rnorm(10))"
 ```
 
 ### `--default-packages`
+
+By default, R code runs with a few packages attached (e.g. `base`, `graphics`, `methods`, `stats`, `tools`). You can configure this by passing the argument `--default-packages`.
 
 ```shell
 Rscript -e "data.table(m = rnorm(10))"
@@ -136,9 +146,15 @@ Rscript --default-packages="data.table,stats" -e "data.table(m = rnorm(10))"
 
 ### `--save` and `--restore`
 
+If you want the state of the environment to be saved before exiting, you can pass `--save`. If this argument is provided, a file `.RData` will be created.
+
+To prove this, the code below creates a variable `some_var` and then exits.
+
 ```shell
 Rscript --save -e "some_var <- 11.5"
 ```
+
+Try running some code that references `some_var` with `--no-restore`. You'll see that R doesn't know anything about that variable.
 
 ```shell
 Rscript --no-restore -e "print(some_var)"
@@ -146,6 +162,8 @@ Rscript --no-restore -e "print(some_var)"
 
 > Error in print(some_var) : object 'some_var' not found
 > Execution halted
+
+If you run the same code with `--restore`, R will first load up the saved environment in `.RData`, and now your code can magically reference `some_var`!
 
 ```shell
 Rscript --restore -e "print(some_var)"
@@ -156,6 +174,10 @@ Rscript --restore -e "print(some_var)"
 `--no-site-file` and `--no-init-file` can be used to avoid loading specific R config files like `.Rprofile`. `--no-environ` can be used to prevent loading `.Renviron` files.
 
 See https://support.rstudio.com/hc/en-us/articles/360047157094-Managing-R-with-Rprofile-Re[…]on-Rprofile-site-Renviron-site-rsession-conf-and-repos-conf for an overview of these different config files.
+
+### `--vanilla`
+
+Running with `--vanilla` combines the effects of `--no-site-file`, `--no-init-file`, `--no-environ`, and `--no-restore`. It's the safest way to ensure that your code's behavior is predictable when run in different environments.
 
 ## Linting Example
 

--- a/r-from-the-command-line/DEMO.md
+++ b/r-from-the-command-line/DEMO.md
@@ -91,6 +91,21 @@ Rscript sample-r-code/print-random-numbers.R
 Rscript -e "library(data.table); data.table(m = rnorm(10))"
 ```
 
+### Redirection of Rscript output
+
+Some R functions, like `print()`, write to stdout of an R process.
+
+Others, like `message()`, `stop()`, and `warning()` print to stderr.
+
+The code below redirects stderr and stdout to two different files, so you can test this.
+
+```shell
+Rscript \
+    -e "print('printing'); message('messaging'); warning('warning'); stop('stopping')" \
+    1> stdout.txt \
+    2> stderr.txt
+```
+
 ### `--help`
 
 `--help` can be used to retrieve documentation about the available arguments.

--- a/r-from-the-command-line/README.md
+++ b/r-from-the-command-line/README.md
@@ -8,4 +8,4 @@ See [`DEMO.md`](./DEMO.md) for the examples used in the talk.
 
 ## Where this talk has been given
 
-* (virtual) [LA R Users](https://www.chicagocloudconference.com/), March 2021 ([slides](https://docs.google.com/presentation/d/1sA7lM752qDtHbmm-efNA_8KyJmk9iIp-le_HMIcccxA/edit?usp=sharing))
+* (virtual) [LA R Users](https://www.chicagocloudconference.com/), March 2021 ([slides](https://docs.google.com/presentation/d/1sA7lM752qDtHbmm-efNA_8KyJmk9iIp-le_HMIcccxA/edit?usp=sharing) | [video](https://www.youtube.com/watch?v=5kmUE-qHziA))

--- a/r-from-the-command-line/lint-basic.R
+++ b/r-from-the-command-line/lint-basic.R
@@ -28,6 +28,7 @@ LINTERS_TO_USE <- list(
     , "unneeded_concatenation" = lintr::unneeded_concatenation_linter
 )
 
+
 lintr::lint_dir(
     path = DIR_TO_LINT
     , linters = LINTERS_TO_USE

--- a/r-from-the-command-line/lint-pretty.R
+++ b/r-from-the-command-line/lint-pretty.R
@@ -1,6 +1,7 @@
 #!/usr/bin/env Rscript
 
 library(argparse)
+library(crayon)
 library(lintr)
 library(spongebob)
 


### PR DESCRIPTION
This adds a video link for the recording of the "R from the Command Line" talk, given at LA R Users. It also adds one more example to the demo code for that talk, and adds a few .gitignore rules for files generated by that demo code.