### PR TITLE
add links to Dask Summit talk

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Click the "title" links below for links to slides, code, and other background in
 |["Economics Consulting"][14]                                                             | ---                                     |
 |["Economics as a Science"][13]                                                           | ---                                     |
 |["Economists Should Learn Data Science"][18]                                             | ---                                     |
+|["How Distributed LightGBM on Dask Works"][29]                                           | ---                                     |
 |["Intro to Cloud Computing"][15]                                                         | [iRisk Lab Hack Night (Apr 2020)][16]   |
 |["LightGBM's Road to CRAN"][7]                                                           | [satRdays Chicago (Apr 2020)][8]        |
 |["People Shape Software"][9]                                                             | [satRdays Chicago (Apr 2019)][10]       |
@@ -59,6 +60,7 @@ Click the "title" links below for links to slides, code, and other background in
 [26]: ./comparing-lightgbm-to-other-r-gbdt-libraries
 [27]: https://www.youtube.com/watch?v=z64JFJQR_J0
 [28]: ./prefect-in-5-minutes
+[29]: ./how-distributed-lightgbm-on-dask-works
 
 ## Writing
 

--- a/how-distributed-lightgbm-on-dask-works/README.md
+++ b/how-distributed-lightgbm-on-dask-works/README.md
@@ -1,0 +1,11 @@
+# How Distributed LightGBM Works
+
+> In this talk, attendees will learn about LightGBM, a popular gradient boosting library from Microsoft. After a high-level overview of the LightGBM algorithm, the talk will describe strategies for distributed training of gradient boosted decision tree (GBDT) models generally, and distributed training of LightGBM models specifically.
+
+> With this base established, the bulk of the talk will cover the current state of LightGBM's Dask integration. Attendees will learn the division of responsibilities between Dask and LightGBM's existing distributed training framework, which is written in C++. The talk will also cover the specific components of the Dask ecosystem that LightGBM relies on.
+
+> The talk offers details on distributed LightGBM training, and describes the main implementation of it using Dask. Attendees will learn which pieces of the Dask ecosystem LightGBM relies on, and what challenges LightGBM faces in using Dask to wrap existing distributed training code written in C++.
+
+## Where this talk has been given
+
+* (virtual) [Dask Distributed Summit 2021](https://summit.dask.org/schedule/presentation/29/how-distributed-lightgbm-on-dask-works/), May 2021 ([slides](https://docs.google.com/presentation/d/1ZsM0aOfRG0ZS3rG5T-Prf0NNUY3ZAsP-G-WTDZ-zi-0/edit?usp=sharing))


### PR DESCRIPTION
Adding a link to my Dask Distributed Summit 2021 talk, "How Distributed LightGBM on Dask works".

https://summit.dask.org/schedule/presentation/29/how-distributed-lightgbm-on-dask-works/