### PR TITLE
add setup for python packaging talk

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,29 +11,30 @@ If you attended one of these talks and have follow-up questions
 
 Click the "title" links below for links to slides, code, and other background information.
 
-| title                                                                                   | video(s)                                |
-|:----------------------------------------------------------------------------------------|:---------------------------------------:|
-|["Building for Small Data Science Teams"][36]                                            | [MLOps Community Podcast][37]           |
-|["Comparing `{lightgbm}` to other R GBDT libraries"][26]                                 | [New York Stats Meetup (May 2021)][27]  |
-|["Dask and LightGBM (light intro)"][34]                                                  | [Austin Python Meetup (November 2021)][35]  |
-|["Economics Consulting"][14]                                                             | ---                                     |
-|["Economics as a Science"][13]                                                           | ---                                     |
-|["Economists Should Learn Data Science"][18]                                             | ---                                     |
-|["Every Way SpotHero Uses Python"][38]                                                   | [ChiPy `__main__` meeting (Mar 2022)][39]|
-|["How Distributed LightGBM on Dask Works"][29]                                           | [Dask Distributed Summit (May 2021)][30]|
-|["Intro to Cloud Computing"][15]                                                         | [iRisk Lab Hack Night (Apr 2020)][16]   |
-|["LightGBM's Road to CRAN"][7]                                                           | [satRdays Chicago (Apr 2020)][8]        |
-|["People Shape Software"][9]                                                             | [satRdays Chicago (Apr 2019)][10]       |
-|["Prefect in 5 Minutes"][28]                                                             | [ChiPy Data SIG (May 2021)][31]         |
-|["Proliferation of New Database Technologies <br>and Implications for Data Science"][11] | [Domino Data Science Pop-Up (Oct 2017)][12] |
-|["R From the Command Line"][23]                                                          | [LA R Users (Mar 2021)][24]             |
-|["Recent Developments in LightGBM"][19]                                                  | [LA Data Science Meetup (Jan 2021)][20] |
-|["Road to a Data Science Career"][3]                                                     | [iRisk Lab Hack Night (Aug 2020)][4]    |
-|["Scaling LightGBM with Python and Dask"][5]                                             | [PyData Montreal (Jan 2021)][21]<br>[Chicago ML (Jan 2021)][22] |
-|["Scaling Machine Learning with Python and Dask"][5]                                     | [Chicago Cloud Conference (Sep 2020)][6]<br>[ODSC East (Apr 2021)][25]|
-|["Using Retry Logic in R HTTP Clients"][17]                                              | ---                                     |
-|["You can do Open Source"][1]                                                            | [satRdays Chicago (Apr 2019)][2]        |
-|["You can and should do Open Source"][32]                                                | [CatBoost: от 0 до 1.0.0][33]           |
+| title                                                                                     |                                video(s)                                |
+|:------------------------------------------------------------------------------------------|:----------------------------------------------------------------------:|
+| ["Building for Small Data Science Teams"][36]                                             |                     [MLOps Community Podcast][37]                      |
+| ["Comparing `{lightgbm}` to other R GBDT libraries"][26]                                  |                 [New York Stats Meetup (May 2021)][27]                 |
+| ["Dask and LightGBM (light intro)"][34]                                                   |               [Austin Python Meetup (November 2021)][35]               |
+| ["Does that CSV belong on PyPI? Probably not"][40]                                        |                                  ---                                   |
+| ["Economics Consulting"][14]                                                              |                                  ---                                   |
+| ["Economics as a Science"][13]                                                            |                                  ---                                   |
+| ["Economists Should Learn Data Science"][18]                                              |                                  ---                                   |
+| ["Every Way SpotHero Uses Python"][38]                                                    |               [ChiPy `__main__` meeting (Mar 2022)][39]                |
+| ["How Distributed LightGBM on Dask Works"][29]                                            |                [Dask Distributed Summit (May 2021)][30]                |
+| ["Intro to Cloud Computing"][15]                                                          |                 [iRisk Lab Hack Night (Apr 2020)][16]                  |
+| ["LightGBM's Road to CRAN"][7]                                                            |                    [satRdays Chicago (Apr 2020)][8]                    |
+| ["People Shape Software"][9]                                                              |                   [satRdays Chicago (Apr 2019)][10]                    |
+| ["Prefect in 5 Minutes"][28]                                                              |                    [ChiPy Data SIG (May 2021)][31]                     |
+| ["Proliferation of New Database Technologies <br>and Implications for Data Science"][11]  |              [Domino Data Science Pop-Up (Oct 2017)][12]               |
+| ["R From the Command Line"][23]                                                           |                      [LA R Users (Mar 2021)][24]                       |
+| ["Recent Developments in LightGBM"][19]                                                   |                [LA Data Science Meetup (Jan 2021)][20]                 |
+| ["Road to a Data Science Career"][3]                                                      |                  [iRisk Lab Hack Night (Aug 2020)][4]                  |
+| ["Scaling LightGBM with Python and Dask"][5]                                              |    [PyData Montreal (Jan 2021)][21]<br>[Chicago ML (Jan 2021)][22]     |
+| ["Scaling Machine Learning with Python and Dask"][5]                                      | [Chicago Cloud Conference (Sep 2020)][6]<br>[ODSC East (Apr 2021)][25] |
+| ["Using Retry Logic in R HTTP Clients"][17]                                               |                                  ---                                   |
+| ["You can do Open Source"][1]                                                             |                    [satRdays Chicago (Apr 2019)][2]                    |
+| ["You can and should do Open Source"][32]                                                 |                     [CatBoost: от 0 до 1.0.0][33]                      |
 
 [1]: ./you-can-do-open-source
 [2]: https://www.youtube.com/watch?v=quFhQvizBE8&t=4h35m15s
@@ -74,6 +75,7 @@ Click the "title" links below for links to slides, code, and other background in
 [37]: https://www.youtube.com/watch?v=yAsPfhI5Jd8
 [38]: ./every-way-spothero-uses-python
 [39]: https://www.youtube.com/watch?v=d5iZONHGQT0&t=38m34s
+[40]: ./does-that-csv-belong-on-pypi
 
 ## Writing
 

--- a/does-that-csv-belong-on-pypi/ABSTRACT-SCIPY-2022.md
+++ b/does-that-csv-belong-on-pypi/ABSTRACT-SCIPY-2022.md
@@ -1,0 +1,74 @@
+# Talk Abstract
+
+This document contains the contents of the abstract submitted to the SciPy 2022 conference committee in February 2022.
+
+<hr>
+
+If you could reduce the size of a popular Python package by 5 MB, would it matter?
+
+In my opinion, the answer is "yes". This talk presents an argument supporting that position.
+
+## What, specifically, will attendees learn from the talk?
+
+### short outline
+
+(00:00 - 03:00) What is a Python package and what files does it usually contain?
+(03:00 - 15:00) Specific examples of issues caused by larger package distributions.
+(15:00 - 20:00) Specific examples of unnecessary files in some popular packages on PyPI.
+(20:00 - 24:00) Guidance on how to keep packages small (e.g. with MANIFEST.in) and how to measure the impact of changes on package size
+(24:00 - 25:00) Call to action to go try to contribute changes like these in open source projects.
+
+### longer outline
+
+Attendees will learn about the types of files that Python packages should contain, at a level of detail much more specific than ".py files and a license".
+
+Next, they'll learn about all of the specific negative impacts of unnecessarily-large packages. This section of the talk will be the longest, and is intended to get attendees thinking holistically and creatively about all the places that a Python package can travel to.
+
+For example, a larger package tarball means:
+
+* increased outbound data transfer for package repositories like PyPI and conda-forge
+    - exacerbated by the fact that newer versions of the pip resolver now often download multiple versions of the same package while searching for compatible sets of versions
+* increased inbound data transfer for anyone installing packages
+    - extra problematic in the presence of weak or unreliable internet connections
+* increased storage footprint for package repositories like PyPI and conda-forge
+* increased image size for container images, which implies:
+    - increased storage footprint
+    - longer pull times for Docker images
+    - which, on services like Kubernetes or Amazon ECS, may translate to increased latency when running containerized Python tasks
+* increased storage footprint in the places where people run Python code
+    - a few MB can be meaningful in storage-sensitive settings like Raspberry Pi / Arduino, or in function-as-a-service cloud services like AWS Lambda (250MB limit for packages, https://docs.aws.amazon.com/lambda/latest/dg/gettingstarted-limits.html) or Google Cloud Functions (500MB limit for packages, https://cloud.google.com/functions/quotas)
+
+After these examples, attendees will learn about some broad classes of "unnecessary files" found in popular Python packages.
+Examples will include test code / data, rendered documentation files, and continuous-integration configs / scripts.
+The goal of this discussion will be to teach attendees some common patterns to look out for.
+
+Attendees will also learn how to reduce the size of packages (e.g. by using rules in a MANIFEST.in file), and how to measure the compressed and uncompressed size of Python packages.
+
+## Who is the intended audience for the talk?
+
+Anyone developing Python packages, or looking for ideas on how to contribute back to the packages they use.
+
+## How do we know you're qualified to talk about this topic?
+
+I have been a maintainer on LightGBM (https://github.com/microsoft/LightGBM) since 2018.
+That project includes a Python package which wraps a large C++ library.
+
+I have firsthand professional experience dealing with the package-size constraints on AWS Lambda, trying to create a Python Lambda using scikit-learn + pandas + lightgbm and doing things like this: https://github.com/jameslamb/talks/blob/a08a519324859e0c3712badf8479bd4a5ad1a2ac/cloud-intro/scripts/create-layers.sh#L49-L52.
+
+I have firsthand experience proposing changes similar to those mentioned in this talk and working with maintainers to get those changes merged into popular projects:
+
+* https://github.com/pandas-dev/pandas/pull/38846
+* https://github.com/pandas-dev/pandas/issues/30741#issuecomment-752751976
+* https://github.com/microsoft/LightGBM/pull/3579
+* https://github.com/microsoft/LightGBM/pull/3639
+* https://github.com/dmlc/xgboost/pull/6565
+
+I've given previous conference talks about open source and Python software. For example:
+
+* "How Distributed LightGBM on Dask Works" (Dask Distributed Summit): https://zoom.us/rec/play/9rwWWxsUq9FiF1oP-ZOwTYoUw3JvI6CgHfhCdS1kQipiOAwR95nwHtELNK4GjFQINWB1DTFl0_9bm1_L.GR3TFusllitynPlt?continueMode=true&_x_zm_rtaid=6y6ososIT12VbHwTYkM8Hg.1644469209953.f5594cbe8503307ac7c98a1cfd1adcde&_x_zm_rhtaid=958
+* "You can and should do open source" (Catboost conference): https://www.youtube.com/watch?v=ObzrXjqWcTY&t=9200s
+* other talks at https://github.com/jameslamb/talks
+
+## Other Notes
+
+Thanks very much for considering me!

--- a/does-that-csv-belong-on-pypi/README.md
+++ b/does-that-csv-belong-on-pypi/README.md
@@ -1,0 +1,12 @@
+# Does that CSV belong on PyPI? Probably not
+
+## Description
+
+> In this talk, attendees will learn the impact of including unnecessary files in Python packages.
+> The talk includes a brief (seriously, BRIEF) overview of Python packaging, followed by specific examples of issues which can result from larger packages.
+> After discussing specific examples of (in the speaker's opinion) unnecessary files found in some popular Python packages, the talk concludes with strategies for reducing package size and a description of how to estimate the impact of changes on package size.
+> If you're known as "the pedantic one" on your team, this talk is for you!
+
+## Where this talk has been given
+
+* (Austin, TX) [SciPy 2022](https://www.scipy2022.scipy.org/), July 2022 ([slides](https://docs.google.com/presentation/d/1fpKe2Qgdo1JETa1fFjUqWtXqFiCG_5mIUqrTsCK8CSI/edit?usp=sharing))


### PR DESCRIPTION
Adds a directory and support files for my upcoming SciPy 2022 talk, "Does that CSV belong on PyPI? Probably not".

Schedule: https://www.scipy2022.scipy.org/

My editor made some changes to most table rows in the table in the README, to visually center them, and tbh I'm not mad about it so just gonna leave them in this PR.