### PR TITLE
fix broken MSAE Alumni links

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
       - id: trailing-whitespace
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.9.7
+    rev: v0.12.0
     hooks:
       # Run the linter.
       - id: ruff
@@ -18,7 +18,7 @@ repos:
         args: ["--config", "pyproject.toml"]
         types_or: [python, jupyter]
   - repo: https://github.com/maxwinterstein/shfmt-py
-    rev: v3.7.0.1
+    rev: v3.11.0.2
     hooks:
       - id: shfmt
         args: ["--indent=4", "--space-redirects", "--write"]
@@ -28,6 +28,6 @@ repos:
       - id: shellcheck
         args: ["--exclude=SC2002"]
   - repo: https://github.com/adrienverge/yamllint
-    rev: v1.35.1
+    rev: v1.37.1
     hooks:
       - id: yamllint

--- a/economic-consulting/README.md
+++ b/economic-consulting/README.md
@@ -10,4 +10,4 @@
 
 ## Links
 
-**slides**: https://jameslamb.github.io/MSAE_Alumni_2015/index.html#1
+Archived repo: https://github.com/jameslamb/MSAE_Alumni_2015

--- a/economic-consulting/index.Rmd
+++ b/economic-consulting/index.Rmd
@@ -359,7 +359,7 @@ Reproducible economic research requires programming. There is no way around it. 
 
 "Version control is a system that records changes to a file or set of files over time so that you can recall specific versions later." - [Git documentation](http://git-scm.com/book/en/v2/Getting-Started-About-Version-Control)
 
-- The software: [Git](http://en.wikipedia.org/wiki/Git_%28software%29) | [GitHub](https://github.com/jameslamb/MSAE_Alumni_2015/commits/gh-pages) (online extension)
+- The software: [Git](http://en.wikipedia.org/wiki/Git_%28software%29) | [GitHub](https://github.com/jameslamb/MSAE_Alumni_2015)
     - Distributed revision control and collaboration system
     - Tracks project history, lets you revert back to old versions
 - An example:

--- a/economics-as-a-science/README.md
+++ b/economics-as-a-science/README.md
@@ -10,4 +10,4 @@
 
 ## Links
 
-**slides**: https://jameslamb.github.io/MSAE_Alumni_2016/index.html#1
+Archived repo: https://github.com/jameslamb/MSAE_Alumni_2016


### PR DESCRIPTION
Fixes #56

I archived these old repos a few months ago, breaking links to their corresponding GitHub Pages sites:

* https://github.com/jameslamb/MSAE_Alumni_2015
* https://github.com/jameslamb/MSAE_Alumni_2016

This removes the links to those sites.

Also updates all `pre-commit` hooks with `pre-commit autoupdate`, since I'm touching this anyway.